### PR TITLE
Scroll Down Boundary

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -162,7 +162,7 @@ impl<'a> Editor<'a> {
     pub fn move_cursor_down(&mut self, num_rows: u16) {
         if self.cursor_location.row_ix + num_rows > self.dimensions.rows {
             // Ensure cursor remains within editor bounds.
-            self.cursor_location.row_ix = self.dimensions.rows;
+            self.cursor_location.row_ix = self.dimensions.rows - 1;
         } else {
             self.cursor_location.row_ix += num_rows;
         }
@@ -269,7 +269,7 @@ mod tests {
     fn constrains_cursor_within_editor_bottom() {
         let mut editor = Editor::new(Dimensions::new(80, 24));
 
-        // Attempt to move the cursor right (should constrain to editor height)
+        // Attempt to move the cursor down (should constrain to editor height)
         editor.move_cursor_down(30);
 
         assert_eq!(editor.cursor_location.row_ix, 23);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -293,6 +293,8 @@ mod tests {
         assert_eq!(editor.get_render_content(), vec!["Hello", "World!"]);
     }
 
+    /// Verifies that the editor trims content vertically when the content is 
+    ///  too tall to fit.
     #[test]
     fn get_render_content_when_too_tall_to_fit() {
         let mut editor = Editor::new(Dimensions::new(10, 1));
@@ -302,6 +304,8 @@ mod tests {
         assert_eq!(editor.get_render_content(), vec!["First"]);
     }
 
+    /// Verifies that the editor trims the rendered content when that content
+    ///  is too wide to fit into the render area.
     #[test]
     fn get_render_content_when_too_wide_to_fit() {
         let mut editor = Editor::new(Dimensions::new(4, 1));
@@ -311,6 +315,8 @@ mod tests {
         assert_eq!(editor.get_render_content(), vec!["Firs"]);
     }
 
+    /// Tests that scrolling one character to the right causes the editor to 
+    ///  return the correct render content.
     #[test]
     fn get_render_content_when_scrolled_width() {
         let mut editor = Editor::new(Dimensions::new(4, 1));
@@ -320,7 +326,9 @@ mod tests {
         editor.scroll_to(1, 0);
         assert_eq!(editor.get_render_content(), vec!["irst"]);
     }
-
+    
+    /// Tests that scrolling beyond the end of the current content correctly 
+    ///  loads the scrolled content into view.
     #[test]
     fn get_render_content_when_scrolled_beyond_end_of_content() {
         let mut editor = Editor::new(Dimensions::new(4, 1));
@@ -331,6 +339,8 @@ mod tests {
         assert_eq!(editor.get_render_content(), vec!["rst"]);
     }
 
+    /// Tests that the editor auto-scrolls when the cursor moves beyond the 
+    ///  right of the current content.
     #[test]
     fn auto_scroll_when_cursor_moved_too_far_right() {
         let mut editor = Editor::new(Dimensions::new(4, 1));
@@ -342,14 +352,19 @@ mod tests {
         assert_eq!(editor.get_render_content(), vec!["irst"]);
     }
 
+    /// Tests that the editor auto-scrolls when the cursor moves beyond the 
+    ///  right of the current content.
+    /// 
+    /// Deliberately scrolls far to many times to verify that the editor stops
+    ///  auto-scrolling once the end of the content is reached.
     #[test]
     fn auto_scroll_when_cursor_moved_too_far_right_many_times() {
         let mut editor = Editor::new(Dimensions::new(4, 1));
         let document = TextDocument::new("First");
         editor.set_content(&document);
 
-        // Move cursor 4 columns to the right (should force scroll)
-        editor.move_cursor_right(40);
+        // Attempt to move cursor right 10 times (should force scroll after 4)
+        editor.move_cursor_right(10);
         assert_eq!(editor.get_render_content(), vec!["irst"]);
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -162,7 +162,7 @@ impl<'a> Editor<'a> {
     pub fn move_cursor_down(&mut self, num_rows: u16) {
         if self.cursor_location.row_ix + num_rows > self.dimensions.rows {
             // Ensure cursor remains within editor bounds.
-            self.cursor_location.row_ix = self.dimensions.rows - 1;
+            self.cursor_location.row_ix = self.dimensions.rows;
         } else {
             self.cursor_location.row_ix += num_rows;
         }

--- a/src/program.rs
+++ b/src/program.rs
@@ -28,7 +28,7 @@ impl<'a> Program<'a> {
         Program {
             core_data: CoreData::new(),
             // TODO: Should be a vector of editors
-            editor: Editor::new(Dimensions::new(80, 24)),
+            editor: Editor::new(Dimensions::new(80, 19)),
             bars: Vec::new(),
             running: false,
             cursor_x: 0,
@@ -62,7 +62,7 @@ impl<'a> Program<'a> {
 
             queue!(
                 w,
-                cursor::MoveTo(self.cursor_x, self.cursor_y)
+                cursor::MoveTo(self.editor.cursor_location.column_ix, self.editor.cursor_location.row_ix)
             )?;
 
             // Flush render queue
@@ -88,27 +88,19 @@ impl<'a> Program<'a> {
                 Event::Key(event) => {
                     if event == KeyCode::Char('h').into() {
                         // TODO: Should move cursor within active editor
-                        if self.cursor_x > 0 {
-                            self.cursor_x -= 1;
-                        }
+                        self.editor.move_cursor_left(1);
                     }
                     if event == KeyCode::Char('j').into() {
                         // TODO: Should move cursor within active editor
-                        if self.cursor_y < 48 {
-                            self.cursor_y += 1;
-                        }
+                        self.editor.move_cursor_down(1);
                     }
                     if event == KeyCode::Char('k').into() {
                         // TODO: Should move cursor within active editor
-                        if self.cursor_y > 0 {
-                            self.cursor_y -= 1;
-                        }
+                        self.editor.move_cursor_up(1);
                     }
                     if event == KeyCode::Char('l').into() {
                         // TODO: Should move cursor within active editor
-                        if self.cursor_x < 50 {
-                            self.cursor_x += 1;
-                        }
+                        self.editor.move_cursor_right(1);
                     }
                     if event == KeyCode::Char('q').into() {
                         self.running = false;


### PR DESCRIPTION
Extends the editor bounds constraints by constraining the cursor inside the bottom boundary.